### PR TITLE
[Jenkinsfile] Clean ~/rpmbuild/SRPMS/ prior to building srpm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ node('docker') {
 
     if (env.BRANCH_NAME == 'master') {
         stage('make') {
+            sh "rm -f ~/rpmbuild/SRPMS/mercator-*.src.rpm"
             sh "./make_rpm.sh --source"
         }
         stage('push to copr') {


### PR DESCRIPTION
From Jenkins [[build 7]](https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/mercator-go-master/7/console) or [[build 8]](https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/mercator-go-master/8/console) it seems that we actually build last but one version in copr:

```
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (make)
[Pipeline] sh
[mercator-go-master] Running shell script
+ ./make_rpm.sh --source
Wrote: /home/jenkins/rpmbuild/SRPMS/mercator-1-19.fc24.src.rpm
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (push to copr)
[Pipeline] sh
[mercator-go-master] Running shell script
+ copr-cli build jpopelka/mercator /home/jenkins/rpmbuild/SRPMS/mercator-1-18.fc24.src.rpm /home/jenkins/rpmbuild/SRPMS/mercator-1-19.fc24.src.rpm
Uploading package /home/jenkins/rpmbuild/SRPMS/mercator-1-18.fc24.src.rpm
Build was added to mercator:
  https://copr.fedorainfracloud.org/coprs/build/600840/
```

And https://copr.fedorainfracloud.org/coprs/build/600840/ points to build of mercator-1-18.fc24.src.rpm, while it should be mercator-1-19.fc24.src.rpm

So this PR makes sure we have empty `~/rpmbuild/SRPMS/` prior to building the srpm.