### PR TITLE
make_rpm.sh requires git

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -12,7 +12,7 @@ load_jenkins_vars() {
 
 prep() {
     yum -y update
-    yum -y install docker rpmdevtools copr-cli
+    yum -y install docker rpmdevtools copr-cli git
     systemctl start docker
 }
 


### PR DESCRIPTION
From https://ci.centos.org/job/devtools-mercator-go-copr-mercator-build-master/4/console

```
./make_rpm.sh: line 20: git: command not found
```