### PR TITLE
Create ~/.config/ prior to creating a file in it

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -21,6 +21,7 @@ run_tests() {
 }
 
 create_copr_config() {
+    mkdir -p ~/.config/
     cat > ~/.config/copr <<EOF
 [copr-cli]
 login = ${COPR_LOGIN_MERCATOR}


### PR DESCRIPTION
From https://ci.centos.org/job/devtools-mercator-go-copr-mercator-build-master/5/console
```
cico_setup.sh: line 24: /root/.config/copr: No such file or directory
```