### PR TITLE
Revert "Suggest to run it locally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Then just invoke `make`:
 
 ```
 make build
+sudo make install
 ```
 
 Some handlers are built/installed by default, some need to be explicitly enabled,
@@ -106,29 +107,45 @@ Note: You can also take a look at our [spec file](mercator.spec), which we use t
 After that, `Mercator` is ready to be used:
 
 ```
-$ ./mercator .
-
-{
-   "items": [
-      {
-         "time": "2017-12-13T12:23:22.08193682+01:00",
-         "path": ".../handlers/dotnet_handler/MercatorDotNet/Properties/AssemblyInfo.cs",
-         "ecosystem": "DotNetSolution",
-         "result": {
-            "copyright": "Copyright ©  2016",
-            "file_version": "1.0.0.0",
-            "guid": "3f6a93dd-da21-4333-8610-ceda4d4853da",
-            "name": "MercatorDotNet",
-            "product": "MercatorDotNet",
-            "version": "1.0.0.0"
-         },
-         "digests": {
-            "manifest": "1e1dcf1f04f12b25cceed23593f2202ae9884e6f"
-         }
-      },
-      {...}
-    ]
-}
+$ mercator jsl/
+[
+   {
+      "path": "/home/podvody/Repos/jsl/setup.py",
+      "ecosystem": "Python",
+      "result": {
+         "author": "Anton Romanovich",
+         "author_email": "anthony.romanovich@gmail.com",
+         "classifiers": [
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: BSD License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.6",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: Implementation :: CPython",
+            "Programming Language :: Python :: Implementation :: PyPy",
+            "Topic :: Software Development :: Libraries :: Python Modules"
+         ],
+         "description": "A Python DSL for defining JSON schemas",
+         "ext_modules": [],
+         "license": "BSD",
+         "long_description": "JSL\n===\n\n.. image:: https://travis-ci.org/aromanovich/jsl.svg?branch=master\n    :target: https://travis-ci.org/aromanovich/jsl\n    :alt: Build Status\n\n.. image:: https://coveralls.io/repos/aromanovich/jsl/badge.svg?branch=master\n    :target: https://coveralls.io/r/aromanovich/jsl?branch=master\n    :alt: Coverage\n\n.. image:: https://readthedocs.org/projects/jsl/badge/?version=latest\n    :target: https://readthedocs.org/projects/jsl/\n    :alt: Documentation\n\n.. image:: http://img.shields.io/pypi/v/jsl.svg\n    :target: https://pypi.python.org/pypi/jsl\n    :alt: PyPI Version\n\n.. image:: http://img.shields.io/pypi/dm/jsl.svg\n    :target: https://pypi.python.org/pypi/jsl\n    :alt: PyPI Downloads\n\nDocumentation_ | GitHub_ |  PyPI_\n\nJSL is a Python DSL for defining JSON Schemas.\n\nExample\n-------\n\n::\n\n    import jsl\n\n    class Entry(jsl.Document):\n        name = jsl.StringField(required=True)\n\n    class File(Entry):\n        content = jsl.StringField(required=True)\n\n    class Directory(Entry):\n        content = jsl.ArrayField(jsl.OneOfField([\n            jsl.DocumentField(File, as_ref=True),\n            jsl.DocumentField(jsl.RECURSIVE_REFERENCE_CONSTANT)\n        ]), required=True)\n\n``Directory.get_schema(ordered=True)`` will return the following JSON schema:\n\n::\n\n    {\n        \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n        \"definitions\": {\n            \"directory\": {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"name\": {\"type\": \"string\"},\n                    \"content\": {\n                        \"type\": \"array\",\n                        \"items\": {\n                            \"oneOf\": [\n                                {\"$ref\": \"#/definitions/file\"},\n                                {\"$ref\": \"#/definitions/directory\"}\n                            ]\n                        }\n                    }\n                },\n                \"required\": [\"name\", \"content\"],\n                \"additionalProperties\": false\n            },\n            \"file\": {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"name\": {\"type\": \"string\"},\n                    \"content\": {\"type\": \"string\"}\n                },\n                \"required\": [\"name\", \"content\"],\n                \"additionalProperties\": false\n            }\n        },\n        \"$ref\": \"#/definitions/directory\"\n    }\n\nInstalling\n----------\n\n::\n\n    pip install jsl\n\nLicense\n-------\n\n`BSD license`_\n\n.. _Documentation: http://jsl.readthedocs.org/\n.. _GitHub: https://github.com/aromanovich/jsl\n.. _PyPI: https://pypi.python.org/pypi/jsl\n.. _BSD license: https://github.com/aromanovich/jsl/blob/master/LICENSE\n",
+         "name": "jsl",
+         "packages": [
+            "jsl",
+            "jsl.fields",
+            "jsl._compat"
+         ],
+         "url": "https://jsl.readthedocs.org",
+         "version": "0.2.1"
+      }
+   }
+]
 ```
 
 ## Tests


### PR DESCRIPTION
This reverts commit 9914814

Turns out it needs a `/usr/share/mercator/handlers.yml` so it has to be installed first.