### PR TITLE
Recursive copy handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ install:
 	mkdir -p ${DESTDIR}/bin ${HANDLERSDIR}
 	cp ${BIN_NAME} ${DESTDIR}/bin/${BIN_NAME}
 	cp handlers.yml ${HANDLERSDIR}
-	cp -f handlers/* ${HANDLERSDIR} || :
+	cp -rf handlers/* ${HANDLERSDIR} || :
 	# bundled python pkginfo module
 	cp -rf handlers/python_handler/pkginfo/ ${HANDLERSDIR}
 	# bundle gradle dependencies


### PR DESCRIPTION
I guess this is another Macintosh problem, whenever I try to run `make install` I get the below message:

```bash
mkdir -p /usr/local/bin /usr/local/share/mercator
cp mercator /usr/local/bin/mercator
cp handlers.yml /usr/local/share/mercator
cp -f handlers/* /usr/local/share/mercator || :
cp: handlers/dotnet_handler is a directory (not copied).
cp: handlers/golang_handler is a directory (not copied).
cp: handlers/gradle_handler is a directory (not copied).
cp: handlers/haskell_handler is a directory (not copied).
cp: handlers/java_handler is a directory (not copied).
cp: handlers/npm_handler is a directory (not copied).
cp: handlers/python_handler is a directory (not copied).
cp: handlers/ruby_handler is a directory (not copied).
cp: handlers/rust_handler is a directory (not copied).
# bundled python pkginfo module
cp -rf handlers/python_handler/pkginfo/ /usr/local/share/mercator
# bundle gradle dependencies
```

It gets fixed by this change.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>